### PR TITLE
Replace singleton with memo of DataFrame obj

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -8,7 +8,7 @@ st.set_page_config(
 )
 
 
-@st.experimental_singleton()
+@st.experimental_memo
 def get_data():
     source = data.stocks()
     source = source[source.date.gt("2004-01-01")]
@@ -116,7 +116,7 @@ import pandas as pd
 import streamlit as st
 from vega_datasets import data
 
-@st.experimental_singleton()
+@st.experimental_memo
 def get_data():
     source = data.stocks()
     source = source[source.date.gt("2004-01-01")]


### PR DESCRIPTION
The object returned by `get_data()` is of type `<class 'pandas.core.frame.DataFrame'>`. The [docs state](https://docs.streamlit.io/library/advanced-features/experimental-cache-primitives#which-to-use-memo-or-singleton) that we should use `st.experimental_memo` when the function's return type is a _data object_, such as a pandas DataFrame.